### PR TITLE
feat: add support for Kubernetes service accounts

### DIFF
--- a/iam_drain.tf
+++ b/iam_drain.tf
@@ -1,15 +1,25 @@
 locals {
   drain_role_assume_role_policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
-      {
+
+    # We're using concat here even though only one of either ECS or Kubernetes can be enabled because
+    # Terraform can't handle different branches of a ternary operator returning different types.
+    Statement = concat(
+      local.ecs_role_assumption_enabled ? [local.ecs_role_assumption_statement] : [],
+      local.kubernetes_role_assumption_enabled ? [{
         Effect = "Allow"
-        Action = "sts:AssumeRole"
         Principal = {
-          Service = "ecs-tasks.${var.aws_dns_suffix}"
+          Federated = "arn:${var.aws_partition}:iam::${var.kubernetes_role_assumption_config.aws_account_id}:oidc-provider/${var.kubernetes_role_assumption_config.oidc_provider}"
         }
-      }
-    ]
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${var.kubernetes_role_assumption_config.oidc_provider}:aud" = "sts.${var.aws_dns_suffix}"
+            "${var.kubernetes_role_assumption_config.oidc_provider}:sub" = "system:serviceaccount:${var.kubernetes_role_assumption_config.namespace}:${var.kubernetes_role_assumption_config.drain_service_account_name}"
+          }
+        }
+      }] : []
+    )
   })
 
   drain_role_policy = jsonencode({

--- a/iam_execution.tf
+++ b/iam_execution.tf
@@ -1,13 +1,7 @@
 locals {
   execution_role_assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect    = "Allow"
-        Action    = "sts:AssumeRole"
-        Principal = { Service = "ecs-tasks.${var.aws_dns_suffix}" }
-      }
-    ]
+    Version   = "2012-10-17"
+    Statement = [local.ecs_role_assumption_statement]
   })
 
   execution_role_policy = jsonencode({
@@ -34,7 +28,7 @@ locals {
     ]
   })
 
-  execution = {
+  execution = var.kubernetes_role_assumption_config == null ? {
     assume_role = local.execution_role_assume_role_policy
 
     # These are objects so it can be used in a for_each loop easily
@@ -44,5 +38,5 @@ locals {
     attachments = {
       "AWS_ECS_TASK_EXECUTION" = "arn:${var.aws_partition}:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
     }
-  }
+  } : null
 }

--- a/iam_scheduler.tf
+++ b/iam_scheduler.tf
@@ -2,13 +2,25 @@ locals {
   scheduler_assume_role_policy = jsonencode(
     {
       Version = "2012-10-17"
-      Statement = [
-        {
-          Effect    = "Allow"
-          Action    = "sts:AssumeRole"
-          Principal = { Service = "ecs-tasks.${var.aws_dns_suffix}" }
-        }
-      ]
+
+      # We're using concat here even though only one of either ECS or Kubernetes can be enabled because
+      # Terraform can't handle different branches of a ternary operator returning different types.
+      Statement = concat(
+        local.ecs_role_assumption_enabled ? [local.ecs_role_assumption_statement] : [],
+        local.kubernetes_role_assumption_enabled ? [{
+          Effect = "Allow"
+          Principal = {
+            Federated = "arn:${var.aws_partition}:iam::${var.kubernetes_role_assumption_config.aws_account_id}:oidc-provider/${var.kubernetes_role_assumption_config.oidc_provider}"
+          }
+          Action = "sts:AssumeRoleWithWebIdentity"
+          Condition = {
+            StringEquals = {
+              "${var.kubernetes_role_assumption_config.oidc_provider}:aud" = "sts.${var.aws_dns_suffix}"
+              "${var.kubernetes_role_assumption_config.oidc_provider}:sub" = "system:serviceaccount:${var.kubernetes_role_assumption_config.namespace}:${var.kubernetes_role_assumption_config.scheduler_service_account_name}"
+            }
+          }
+        }] : []
+      )
     }
   )
 

--- a/iam_server.tf
+++ b/iam_server.tf
@@ -1,13 +1,25 @@
 locals {
   server_assume_role_policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
-      {
-        Effect    = "Allow"
-        Action    = "sts:AssumeRole"
-        Principal = { Service = "ecs-tasks.${var.aws_dns_suffix}" }
-      }
-    ]
+
+    # We're using concat here even though only one of either ECS or Kubernetes can be enabled because
+    # Terraform can't handle different branches of a ternary operator returning different types.
+    Statement = concat(
+      local.ecs_role_assumption_enabled ? [local.ecs_role_assumption_statement] : [],
+      local.kubernetes_role_assumption_enabled ? [{
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:${var.aws_partition}:iam::${var.kubernetes_role_assumption_config.aws_account_id}:oidc-provider/${var.kubernetes_role_assumption_config.oidc_provider}"
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${var.kubernetes_role_assumption_config.oidc_provider}:aud" = "sts.${var.aws_dns_suffix}"
+            "${var.kubernetes_role_assumption_config.oidc_provider}:sub" = "system:serviceaccount:${var.kubernetes_role_assumption_config.namespace}:${var.kubernetes_role_assumption_config.server_service_account_name}"
+          }
+        }
+      }] : []
+    )
   })
 
   server_policy = jsonencode({

--- a/main.tf
+++ b/main.tf
@@ -9,4 +9,15 @@ locals {
   uploads_bucket_arn                  = "arn:${var.aws_partition}:s3:::${var.uploads_bucket_name}"
   user_uploaded_workspaces_bucket_arn = "arn:${var.aws_partition}:s3:::${var.user_uploaded_workspaces_bucket_name}"
   workspace_bucket_arn                = "arn:${var.aws_partition}:s3:::${var.workspace_bucket_name}"
+
+  ecs_role_assumption_statement = {
+    Effect = "Allow"
+    Action = "sts:AssumeRole"
+    Principal = {
+      Service = "ecs-tasks.${var.aws_dns_suffix}"
+    }
+  }
+
+  ecs_role_assumption_enabled        = var.kubernetes_role_assumption_config == null
+  kubernetes_role_assumption_enabled = var.kubernetes_role_assumption_config != null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -80,3 +80,16 @@ variable "write_as_files" {
   description = "Whether to write the policies as files to disk"
   default     = false
 }
+
+variable "kubernetes_role_assumption_config" {
+  type = object({
+    aws_account_id                 = string
+    oidc_provider                  = string
+    namespace                      = string
+    server_service_account_name    = string
+    drain_service_account_name     = string
+    scheduler_service_account_name = string
+  })
+  description = "The configuration to use to allow pods running in EKS to assume the roles. By default this is null and ECS role assumption statements will be generated."
+  default     = null
+}


### PR DESCRIPTION
I've adjusted the assume role policies for the server, drain and scheduler to allow them to be assumed by a Kubernetes service account. I've left ECS role assumption as the default for backwards compatibility.