### PR TITLE
refactor: remove aws_dns_suffix variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ module "self_hosted_roles" {
 
   write_as_files = false
   aws_partition  = data.aws_partition.current.partition
-  aws_dns_suffix = data.aws_partition.current.dns_suffix
 
   kms_encryption_key_arn               = "arn:aws:kms:us-west-2:123456789012:key/1234abcd-12ab-34cd-56ef-123456789012"
   kms_signing_key_arn                  = "arn:aws:kms:us-west-2:123456789012:key/1234abcd-12ab-34cd-56ef-123456789012"
@@ -162,7 +161,6 @@ module "self_hosted_roles" {
 
   write_as_files = true
   aws_partition  = data.aws_partition.current.partition
-  aws_dns_suffix = data.aws_partition.current.dns_suffix
 
   kms_encryption_key_arn               = "arn:aws:kms:us-west-2:123456789012:key/1234abcd-12ab-34cd-56ef-123456789012"
   kms_signing_key_arn                  = "arn:aws:kms:us-west-2:123456789012:key/1234abcd-12ab-34cd-56ef-123456789012"

--- a/iam_drain.tf
+++ b/iam_drain.tf
@@ -14,7 +14,7 @@ locals {
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
           StringEquals = {
-            "${var.kubernetes_role_assumption_config.oidc_provider}:aud" = "sts.${var.aws_dns_suffix}"
+            "${var.kubernetes_role_assumption_config.oidc_provider}:aud" = "sts.amazonaws.com"
             "${var.kubernetes_role_assumption_config.oidc_provider}:sub" = "system:serviceaccount:${var.kubernetes_role_assumption_config.namespace}:${var.kubernetes_role_assumption_config.drain_service_account_name}"
           }
         }

--- a/iam_scheduler.tf
+++ b/iam_scheduler.tf
@@ -15,7 +15,7 @@ locals {
           Action = "sts:AssumeRoleWithWebIdentity"
           Condition = {
             StringEquals = {
-              "${var.kubernetes_role_assumption_config.oidc_provider}:aud" = "sts.${var.aws_dns_suffix}"
+              "${var.kubernetes_role_assumption_config.oidc_provider}:aud" = "sts.amazonaws.com"
               "${var.kubernetes_role_assumption_config.oidc_provider}:sub" = "system:serviceaccount:${var.kubernetes_role_assumption_config.namespace}:${var.kubernetes_role_assumption_config.scheduler_service_account_name}"
             }
           }

--- a/iam_server.tf
+++ b/iam_server.tf
@@ -14,7 +14,7 @@ locals {
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
           StringEquals = {
-            "${var.kubernetes_role_assumption_config.oidc_provider}:aud" = "sts.${var.aws_dns_suffix}"
+            "${var.kubernetes_role_assumption_config.oidc_provider}:aud" = "sts.amazonaws.com"
             "${var.kubernetes_role_assumption_config.oidc_provider}:sub" = "system:serviceaccount:${var.kubernetes_role_assumption_config.namespace}:${var.kubernetes_role_assumption_config.server_service_account_name}"
           }
         }

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ locals {
     Effect = "Allow"
     Action = "sts:AssumeRole"
     Principal = {
-      Service = "ecs-tasks.${var.aws_dns_suffix}"
+      Service = "ecs-tasks.amazonaws.com"
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,12 +4,6 @@ variable "aws_partition" {
   default     = "aws"
 }
 
-variable "aws_dns_suffix" {
-  type        = string
-  description = "The DNS suffix for the AWS region."
-  default     = "amazonaws.com"
-}
-
 variable "kms_encryption_key_arn" {
   type        = string
   description = "The ARN of the KMS key ID to use for in-app encryption."


### PR DESCRIPTION
Apparently they're consistent in GovCloud and China too. My bad.