### PR TITLE
fix: added missing field to variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -77,12 +77,13 @@ variable "write_as_files" {
 
 variable "kubernetes_role_assumption_config" {
   type = object({
-    aws_account_id                 = string
-    oidc_provider                  = string
-    namespace                      = string
-    server_service_account_name    = string
-    drain_service_account_name     = string
-    scheduler_service_account_name = string
+    aws_account_id                   = string
+    oidc_provider                    = string
+    namespace                        = string
+    server_service_account_name      = string
+    drain_service_account_name       = string
+    scheduler_service_account_name   = string
+    vcs_gateway_service_account_name = string
   })
   description = "The configuration to use to allow pods running in EKS to assume the roles. By default this is null and ECS role assumption statements will be generated."
   default     = null


### PR DESCRIPTION
## Summary

Adds the missing `vcs_gateway_service_account_name` field to the `kubernetes_role_assumption_config` variable definition to support VCS Gateway role assumption in Kubernetes environments.

## Motivation

The VCS Gateway IAM role configuration (added in #9) references `var.kubernetes_role_assumption_config.vcs_gateway_service_account_name` in `iam_vcs_gateway.tf:18`, but this field was not defined in the variable schema. This causes validation errors when users attempt to use Kubernetes role assumption with the VCS Gateway component.

## Changes

- Added `vcs_gateway_service_account_name` field to the `kubernetes_role_assumption_config` variable object type
- Aligned field formatting for consistency

## Fixes

- Fixes validation errors when using Kubernetes role assumption with VCS Gateway
- Completes the VCS Gateway Kubernetes support added in #9

## Usage

When configuring Kubernetes role assumption, users can now provide the VCS Gateway service account name:

```hcl
kubernetes_role_assumption_config = {
  aws_account_id                   = "123456789012"
  oidc_provider                    = "oidc.eks.region.amazonaws.com/id/EXAMPLE"
  namespace                        = "spacelift"
  server_service_account_name      = "spacelift-server"
  drain_service_account_name       = "spacelift-drain"
  scheduler_service_account_name   = "spacelift-scheduler"
  vcs_gateway_service_account_name = "spacelift-vcs-gateway"
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `vcs_gateway_service_account_name` to `kubernetes_role_assumption_config` in `variables.tf` to enable VCS Gateway role assumption in Kubernetes (plus minor field alignment).
> 
> - **Terraform Variables**:
>   - Update `variables.tf` `kubernetes_role_assumption_config` object to include `vcs_gateway_service_account_name`.
>   - Align field formatting for consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23a73cf1bcb537f2cab7b29cc1b0180534149e94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->