### PR TITLE
feat: add sts:TagSession action to AssumeRole policy

### DIFF
--- a/iam_drain_and_server.tf
+++ b/iam_drain_and_server.tf
@@ -13,7 +13,7 @@ locals {
       },
       {
         Effect   = "Allow"
-        Action   = ["sts:AssumeRole"],
+        Action   = ["sts:AssumeRole", "sts:TagSession"],
         Resource = ["*"],
       },
       {

--- a/iam_scheduler.tf
+++ b/iam_scheduler.tf
@@ -35,7 +35,7 @@ locals {
         },
         {
           Effect   = "Allow"
-          Action   = ["sts:AssumeRole"]
+          Action   = ["sts:AssumeRole", "sts:TagSession"]
           Resource = ["*"]
         },
         {


### PR DESCRIPTION
For an upcoming feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `sts:TagSession` to STS permissions in drain/server and scheduler IAM policies.
> 
> - **IAM Policies**:
>   - Update `locals.drain_and_server_policy` in `iam_drain_and_server.tf` to include `sts:TagSession` alongside `sts:AssumeRole`.
>   - Update `locals.scheduler_policy` in `iam_scheduler.tf` to include `sts:TagSession` alongside `sts:AssumeRole`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07e15acc398b9367085dbe3975e71a53cc5c931c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->