### PR TITLE
Revert "feat: add sts:TagSession action to AssumeRole policy (#11)"

### DIFF
--- a/iam_drain_and_server.tf
+++ b/iam_drain_and_server.tf
@@ -13,7 +13,7 @@ locals {
       },
       {
         Effect   = "Allow"
-        Action   = ["sts:AssumeRole", "sts:TagSession"],
+        Action   = ["sts:AssumeRole"],
         Resource = ["*"],
       },
       {

--- a/iam_scheduler.tf
+++ b/iam_scheduler.tf
@@ -35,7 +35,7 @@ locals {
         },
         {
           Effect   = "Allow"
-          Action   = ["sts:AssumeRole", "sts:TagSession"]
+          Action   = ["sts:AssumeRole"]
           Resource = ["*"]
         },
         {


### PR DESCRIPTION
It's not needed as it doesn't require a separate permission.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `sts:TagSession` from AssumeRole permissions in `iam_scheduler.tf` and `iam_drain_and_server.tf`.
> 
> - **IAM Policies**:
>   - **`iam_scheduler.tf`**: Drop `sts:TagSession` from `scheduler_policy` AssumeRole actions (retain `sts:AssumeRole`).
>   - **`iam_drain_and_server.tf`**: Drop `sts:TagSession` from `drain_and_server_policy` AssumeRole actions (retain `sts:AssumeRole`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fdbe693ceedc47f3433fef33982adf9d1834535. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->