### PR TITLE
feat: add AWS X-Ray permissions to IAM policies

### DIFF
--- a/iam_drain_and_server.tf
+++ b/iam_drain_and_server.tf
@@ -7,9 +7,19 @@ locals {
     Version = "2012-10-17"
     Statement = concat([
       {
-        Effect   = "Allow"
-        Action   = ["cloudwatch:PutMetricData"],
-        Resource = ["*"],
+        Effect = "Allow"
+        Action = [
+          "xray:PutTraceSegments",
+          "xray:PutTelemetryRecords",
+          "xray:GetSamplingRules",
+          "xray:GetSamplingTargets",
+          "xray:GetSamplingStatisticSummaries",
+          "cloudwatch:PutMetricData",
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = ["*"]
       },
       {
         Effect   = "Allow"

--- a/iam_scheduler.tf
+++ b/iam_scheduler.tf
@@ -29,9 +29,19 @@ locals {
     Statement = concat(
       [
         {
-          Effect   = "Allow"
-          Action   = ["cloudwatch:PutMetricData"]
-          Resource = ["*"]
+          Effect = "Allow"
+          Action = [
+            "xray:PutTraceSegments",
+            "xray:PutTelemetryRecords",
+            "xray:GetSamplingRules",
+            "xray:GetSamplingTargets",
+            "xray:GetSamplingStatisticSummaries",
+            "cloudwatch:PutMetricData",
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents"
+          ]
+          Resource = "*"
         },
         {
           Effect   = "Allow"

--- a/iam_vcs_gateway.tf
+++ b/iam_vcs_gateway.tf
@@ -26,9 +26,19 @@ locals {
     Version = "2012-10-17"
     Statement = [
       {
-        Effect   = "Allow"
-        Action   = ["cloudwatch:PutMetricData"]
-        Resource = ["*"]
+        Effect = "Allow"
+        Action = [
+          "xray:PutTraceSegments",
+          "xray:PutTelemetryRecords",
+          "xray:GetSamplingRules",
+          "xray:GetSamplingTargets",
+          "xray:GetSamplingStatisticSummaries",
+          "cloudwatch:PutMetricData",
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "*"
       },
     ]
   })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds AWS X-Ray and CloudWatch Logs permissions to IAM policies for drain/server, scheduler, and VCS gateway.
> 
> - **IAM Policies**:
>   - Expand permissions to include AWS X-Ray tracing and CloudWatch Logs write actions (`xray:*`, `logs:*`) alongside `cloudwatch:PutMetricData`.
>   - Updated in:
>     - `iam_drain_and_server.tf` (`locals.drain_and_server_policy`)
>     - `iam_scheduler.tf` (`locals.scheduler_policy`)
>     - `iam_vcs_gateway.tf` (`locals.vcs_gateway_policy`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a93ec67a8ae93f2d009dc7f3e3a25cbe9e8d6f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->