### PR TITLE
Add the tag session permission

### DIFF
--- a/iam_drain_and_server.tf
+++ b/iam_drain_and_server.tf
@@ -23,7 +23,7 @@ locals {
       },
       {
         Effect   = "Allow"
-        Action   = ["sts:AssumeRole"],
+        Action   = ["sts:AssumeRole", "sts:TagSession"],
         Resource = ["*"],
       },
       {

--- a/iam_scheduler.tf
+++ b/iam_scheduler.tf
@@ -45,7 +45,7 @@ locals {
         },
         {
           Effect   = "Allow"
-          Action   = ["sts:AssumeRole"]
+          Action   = ["sts:AssumeRole", "sts:TagSession"]
           Resource = ["*"]
         },
         {


### PR DESCRIPTION
It turns out we do need it for latest release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds missing `sts:TagSession` permission to IAM policies to allow session tagging when assuming roles.
> 
> - Update `iam_drain_and_server.tf` shared policy to include `sts:TagSession` alongside `sts:AssumeRole`
> - Update `iam_scheduler.tf` scheduler policy similarly to include `sts:TagSession`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36d0ef2bd57c77af7ce587b864ae5e008d60cf93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->