### PR TITLE
fix: move can_manage_s3_workspaces from drain to drain-and-server policy

### DIFF
--- a/iam_drain.tf
+++ b/iam_drain.tf
@@ -37,11 +37,6 @@ locals {
       },
       {
         Effect   = "Allow"
-        Action   = ["s3:AbortMultipartUpload", "s3:DeleteObject", "s3:GetObject", "s3:PutObject"]
-        Resource = [local.workspace_bucket_arn, "${local.workspace_bucket_arn}/*"]
-      },
-      {
-        Effect   = "Allow"
         Action   = ["s3:GetObject"]
         Resource = [local.large_queue_messages_bucket_arn, "${local.large_queue_messages_bucket_arn}/*"]
       },

--- a/iam_drain_and_server.tf
+++ b/iam_drain_and_server.tf
@@ -67,6 +67,19 @@ locals {
       {
         Effect = "Allow",
         Action = [
+          "s3:AbortMultipartUpload",
+          "s3:DeleteObject",
+          "s3:GetObject",
+          "s3:PutObject",
+        ],
+        Resource = [
+          local.workspace_bucket_arn,
+          "${local.workspace_bucket_arn}/*",
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
           "s3:GetObject",
           "s3:ListBucket"
         ],


### PR DESCRIPTION
related to https://github.com/spacelift-io/backend/pull/13809

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates IAM policies for S3 workspace bucket access; mis-scoping could break drain jobs that still rely on the `DRAIN` role or unintentionally broaden access for the shared role.
> 
> **Overview**
> Moves `s3` read/write permissions for `local.workspace_bucket_arn` out of the `DRAIN` role policy (`iam_drain.tf`) and into the shared `DRAIN_AND_SERVER` policy (`iam_drain_and_server.tf`).
> 
> Net effect: only the combined drain+server role retains `AbortMultipartUpload`/`GetObject`/`PutObject`/`DeleteObject` access to the workspace bucket; the standalone drain role no longer has it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bbcef788a655cabf262a04aabd3c80126174fa3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->