### PR TITLE
fix: move metadata_bucket permissions from drain to drain-and-server policy

### DIFF
--- a/iam_drain.tf
+++ b/iam_drain.tf
@@ -32,11 +32,6 @@ locals {
       },
       {
         Effect   = "Allow"
-        Action   = ["s3:AbortMultipartUpload", "s3:DeleteObject", "s3:GetObject", "s3:PutObject"]
-        Resource = [local.metadata_bucket_arn, "${local.metadata_bucket_arn}/*"]
-      },
-      {
-        Effect   = "Allow"
         Action   = ["s3:GetObject"]
         Resource = [local.large_queue_messages_bucket_arn, "${local.large_queue_messages_bucket_arn}/*"]
       },

--- a/iam_drain_and_server.tf
+++ b/iam_drain_and_server.tf
@@ -80,6 +80,19 @@ locals {
       {
         Effect = "Allow",
         Action = [
+          "s3:AbortMultipartUpload",
+          "s3:DeleteObject",
+          "s3:GetObject",
+          "s3:PutObject",
+        ],
+        Resource = [
+          local.metadata_bucket_arn,
+          "${local.metadata_bucket_arn}/*",
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
           "s3:GetObject",
           "s3:ListBucket"
         ],


### PR DESCRIPTION
Same change as #15 but for the metadata bucket - the server needs access to it too.

Related: https://github.com/spacelift-io/self-hosted/pull/1388