### PR TITLE
feat: grant drain sqs:SendMessage on cronjobs queue

### DIFF
--- a/iam_drain.tf
+++ b/iam_drain.tf
@@ -59,6 +59,13 @@ locals {
           var.sqs_queues.iot,
           var.sqs_queues.events_inbox
         ]
+      }] : [],
+      local.has_sqs_queues ? [{
+        Effect = "Allow"
+        Action = [
+          "sqs:SendMessage"
+        ]
+        Resource = [var.sqs_queues.cronjobs]
     }] : [])
   })
 


### PR DESCRIPTION
We are moving the cron scheduler into the drain so we no longer have to run it as a separate service. When the embedded scheduler is turned on, the drain needs to put cronjob messages on the cronjobs SQS queue, the same way the standalone scheduler does today.

This PR gives the drain role the `sqs:SendMessage` permission on the cronjobs queue. It only applies when SQS is used as the message queue. The scheduler role already has this exact permission, so here we just give the drain the same access.

The change is safe to apply by itself. It only grants a permission and does not turn anything on. The new `DRAIN_SCHEDULER_ENABLED` flag stays off until we enable it per environment later.

Backend PR: https://github.com/spacelift-io/backend/pull/14922
